### PR TITLE
Added RichText component to Page content type

### DIFF
--- a/api/page/models/page.settings.json
+++ b/api/page/models/page.settings.json
@@ -16,7 +16,8 @@
       "components": [
         "page-elements.list",
         "page-elements.quote",
-        "page-elements.text-call-to-action"
+        "page-elements.text-call-to-action",
+        "page-elements.rich-text"
       ]
     },
     "Title_EN": {

--- a/components/page-elements/rich-text.json
+++ b/components/page-elements/rich-text.json
@@ -1,0 +1,19 @@
+{
+  "collectionName": "components_page_elements_rich_text",
+  "info": {
+    "name": "RichText",
+    "icon": "quote-right",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Rich_Text_Content_EN" :{
+      "type": "richtext",
+      "required": true
+    },
+    "Rich_Text_Content_FR" :{
+      "type": "richtext",
+      "required": true
+    }
+  }
+}


### PR DESCRIPTION
[Strapi RichText component](https://trello.com/c/LE2I30z2/219-219-strapi-component-for-text-rich-text-content)

This PR adds a RichText component under components/page-elements to be used with the Page content-type. 