### PR TITLE
Added new fields and page elements

### DIFF
--- a/api/page/models/page.settings.json
+++ b/api/page/models/page.settings.json
@@ -17,7 +17,8 @@
         "page-elements.list",
         "page-elements.quote",
         "page-elements.text-call-to-action",
-        "page-elements.rich-text"
+        "page-elements.rich-text",
+        "page-elements.call-to-action"
       ]
     },
     "Title_EN": {
@@ -52,15 +53,31 @@
       "plugin": "upload",
       "required": false
     },
+    "BannerTitle_EN": {
+      "type": "string",
+      "required": "false"
+    },
+    "BannerTitle_FR": {
+      "type": "string",
+      "required": "false"
+    },
+    "BannerText_EN": {
+      "type": "string",
+      "required": "false"
+    },
+    "BannerText_FR": {
+      "type": "string",
+      "required": "false"
+    },
     "PagePath_EN": {
       "type": "string",
       "required": true,
-      "regex": "^([a-z]*-[a-z]*)*$"
+      "regex": "^([a-z]-?)*$"
     },
     "PagePath_FR": {
       "type": "string",
       "required": true,
-      "regex": "^([a-z]*-[a-z]*)*$"
+      "regex": "^([a-z]-?)*$"
     }
   }
 }

--- a/components/page-elements/call-to-action.json
+++ b/components/page-elements/call-to-action.json
@@ -22,6 +22,14 @@
     "Link_FR": {
       "type": "string",
       "required": true
+    },
+    "ButtonType": {
+      "type": "enumeration",
+      "enum": [
+        "secondary",
+        "tertiary",
+        "disabled"
+      ]
     }
   }
 }

--- a/components/page-elements/call-to-action.json
+++ b/components/page-elements/call-to-action.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_page_elements_call_to_action_button",
+  "info": {
+    "name": "CallToActionButton",
+    "icon": "external-link-alt",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "Text_EN": {
+      "type": "string",
+      "required": true
+    },
+    "Text_FR": {
+      "type": "string",
+      "required": true
+    },
+    "Link_EN": {
+      "type": "string",
+      "required": true
+    },
+    "Link_FR": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/components/page-elements/quote.json
+++ b/components/page-elements/quote.json
@@ -15,6 +15,10 @@
       "type": "string",
       "required": true
     },
+    "Author": {
+      "type": "string",
+      "required": true
+    },
     "Size": {
       "type": "enumeration",
       "enum": [

--- a/components/page-elements/rich-text.json
+++ b/components/page-elements/rich-text.json
@@ -7,6 +7,14 @@
   },
   "options": {},
   "attributes": {
+    "Title_EN": {
+      "type": "string",
+      "required": true
+    },
+    "Title_FR": {
+      "type": "string",
+      "required": true
+    },
     "Rich_Text_Content_EN" :{
       "type": "richtext",
       "required": true

--- a/components/page-elements/rich-text.json
+++ b/components/page-elements/rich-text.json
@@ -7,20 +7,24 @@
   },
   "options": {},
   "attributes": {
-    "Title_EN": {
-      "type": "string",
-      "required": true
-    },
-    "Title_FR": {
-      "type": "string",
-      "required": true
-    },
     "Rich_Text_Content_EN" :{
       "type": "richtext",
       "required": true
     },
     "Rich_Text_Content_FR" :{
       "type": "richtext",
+      "required": true
+    },
+    "Size": {
+      "type": "enumeration",
+      "enum": [
+        "full",
+        "three_quarters",
+        "two_thirds",
+        "half",
+        "third",
+        "quarter"
+      ],
       "required": true
     }
   }

--- a/components/page-elements/text-call-to-action.json
+++ b/components/page-elements/text-call-to-action.json
@@ -35,6 +35,14 @@
       ],
       "required": true
     },
+    "ButtonText_EN": {
+      "type": "string",
+      "required": true
+    },
+    "ButtonText_FR": {
+      "type": "string",
+      "required": true
+    },
     "Link_EN": {
       "type": "string",
       "required": true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - api
     ports:
-      - 3000:80
+      - 8000:80
     build:
       context: .
       dockerfile: Admin.Dockerfile


### PR DESCRIPTION
As I was working through the dynamic page task I noticed a few fields and page elements we're missing from the CMS to be able to support our needs.

Here's a summary:

- Added BannerTitle and BannerText to the Page content-type to support adding text to banners
- Changed regex for PagePath in Page content type to support paths with "-" characters
- Created a new **call-to-action** component/page-element for the Page content type to support adding a call to action button on pages
- Added "author" field to Quote component/page-element to support adding an author
- Added "ButtonText" field to text-call-to-action component/page-element to support labelling the button

- Changed admin section of the docker-compose.yml to map port 8000 instead of 3000 as the frontend app uses port 3000.