### PR TITLE
Update project tags

### DIFF
--- a/api/experiment/models/experiment.settings.json
+++ b/api/experiment/models/experiment.settings.json
@@ -33,7 +33,7 @@
       "type": "string",
       "regex": "((\/.*)|())"
     },
-    "ExperimentStatus_EN": {
+    "ExperimentStatus": {
       "type": "enumeration",
       "enum": [
         "upcoming_projects",

--- a/api/experiment/models/experiment.settings.json
+++ b/api/experiment/models/experiment.settings.json
@@ -33,14 +33,14 @@
       "type": "string",
       "regex": "((\/.*)|())"
     },
-    "ExperimentStatus": {
+    "ExperimentStatus_EN": {
       "type": "enumeration",
       "enum": [
-        "active",
-        "coming_soon",
-        "alpha"
+        "upcoming_projects",
+        "current_projects",
+        "past_projects"
       ],
-      "default": "coming_soon"
+      "default": "upcoming_projects"
     }
   }
 }


### PR DESCRIPTION
Updated project tags to new specification.

Before:
- active
- coming_soon
- alpha

After:
- upcoming_projects
- current_projects
- past_projects