### PR TITLE
more content types

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
-	"latest": "4.1.1",
-	"lastUpdateCheck": 1646061981695,
+	"latest": "4.1.2",
+	"lastUpdateCheck": 1646321909968,
 	"lastNotification": 1646061981669
 }

--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
 	"latest": "4.1.2",
-	"lastUpdateCheck": 1646321909968,
+	"lastUpdateCheck": 1646410633164,
 	"lastNotification": 1646061981669
 }

--- a/src/api/page-content/content-types/page-content/schema.json
+++ b/src/api/page-content/content-types/page-content/schema.json
@@ -17,6 +17,11 @@
       "type": "component",
       "repeatable": false,
       "component": "page-element.home"
+    },
+    "projects": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.project"
     }
   }
 }

--- a/src/api/page-content/content-types/page-content/schema.json
+++ b/src/api/page-content/content-types/page-content/schema.json
@@ -22,6 +22,11 @@
       "type": "component",
       "repeatable": false,
       "component": "page-element.project"
+    },
+    "about": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.about"
     }
   }
 }

--- a/src/api/page-content/documentation/1.0.0/page-content.json
+++ b/src/api/page-content/documentation/1.0.0/page-content.json
@@ -576,6 +576,97 @@
                                   }
                                 }
                               },
+                              "about": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "siteNavigation": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "siteTitle": {
+                                        "type": "string"
+                                      },
+                                      "home": {
+                                        "type": "string"
+                                      },
+                                      "projects": {
+                                        "type": "string"
+                                      },
+                                      "about": {
+                                        "type": "string"
+                                      },
+                                      "signupInfo": {
+                                        "type": "string"
+                                      },
+                                      "signup": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "callToAction": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "href": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "textField": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "heading": {
+                                          "type": "string"
+                                        },
+                                        "paragraph": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "listItem": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
                               "createdAt": {
                                 "type": "string",
                                 "format": "date-time"
@@ -1712,6 +1803,97 @@
                                 }
                               }
                             },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -2348,6 +2530,82 @@
                           }
                         }
                       },
+                      "about": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -2960,6 +3218,97 @@
                                     },
                                     "signup": {
                                       "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 }
@@ -4010,6 +4359,97 @@
                                 }
                               }
                             },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -4652,6 +5092,82 @@
                               },
                               "signup": {
                                 "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "about": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
                               }
                             }
                           }

--- a/src/api/page-content/documentation/1.0.0/page-content.json
+++ b/src/api/page-content/documentation/1.0.0/page-content.json
@@ -468,6 +468,20 @@
                                         }
                                       }
                                     }
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "listItem": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
                                   }
                                 }
                               },
@@ -1695,6 +1709,20 @@
                                       }
                                     }
                                   }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -2437,6 +2465,17 @@
                                 }
                               }
                             }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
+                              }
+                            }
                           }
                         }
                       },
@@ -3111,6 +3150,20 @@
                                         "type": "string"
                                       },
                                       "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
                                         "type": "string"
                                       }
                                     }
@@ -4251,6 +4304,20 @@
                                       }
                                     }
                                   }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -5000,6 +5067,17 @@
                                   "type": "string"
                                 },
                                 "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
                                   "type": "string"
                                 }
                               }

--- a/src/api/page-content/documentation/1.0.0/page-content.json
+++ b/src/api/page-content/documentation/1.0.0/page-content.json
@@ -471,6 +471,85 @@
                                   }
                                 }
                               },
+                              "projects": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "experiment": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "type": "string",
+                                        "enum": [
+                                          "upcoming_projects",
+                                          "current_projects",
+                                          "past_projects"
+                                        ]
+                                      },
+                                      "link": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "filterText": {
+                                    "type": "string"
+                                  },
+                                  "textField": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "heading": {
+                                          "type": "string"
+                                        },
+                                        "paragraph": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "callToAction": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "href": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
                               "createdAt": {
                                 "type": "string",
                                 "format": "date-time"
@@ -1502,6 +1581,85 @@
                                 }
                               }
                             },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -2048,6 +2206,73 @@
                           }
                         }
                       },
+                      "projects": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "experiment": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "upcoming_projects",
+                                  "current_projects",
+                                  "past_projects"
+                                ]
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "filterText": {
+                            "type": "string"
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -2555,6 +2780,85 @@
                                       "paragraph": {
                                         "type": "string"
                                       }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
                                     }
                                   }
                                 }
@@ -3500,6 +3804,85 @@
                                 }
                               }
                             },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -4052,6 +4435,73 @@
                                 "paragraph": {
                                   "type": "string"
                                 }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "projects": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "experiment": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "upcoming_projects",
+                                  "current_projects",
+                                  "past_projects"
+                                ]
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "filterText": {
+                            "type": "string"
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
                               }
                             }
                           }

--- a/src/api/page-content/documentation/1.0.0/page-content.json
+++ b/src/api/page-content/documentation/1.0.0/page-content.json
@@ -547,6 +547,32 @@
                                         "type": "string"
                                       }
                                     }
+                                  },
+                                  "siteNavigation": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "siteTitle": {
+                                        "type": "string"
+                                      },
+                                      "home": {
+                                        "type": "string"
+                                      },
+                                      "projects": {
+                                        "type": "string"
+                                      },
+                                      "about": {
+                                        "type": "string"
+                                      },
+                                      "signupInfo": {
+                                        "type": "string"
+                                      },
+                                      "signup": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
                               },
@@ -1657,6 +1683,32 @@
                                       "type": "string"
                                     }
                                   }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -2270,6 +2322,29 @@
                                 "type": "string"
                               }
                             }
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -2858,6 +2933,32 @@
                                       "type": "string"
                                     },
                                     "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
                                       "type": "string"
                                     }
                                   }
@@ -3880,6 +3981,32 @@
                                       "type": "string"
                                     }
                                   }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -4501,6 +4628,29 @@
                                 "type": "string"
                               },
                               "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
                                 "type": "string"
                               }
                             }

--- a/src/components/page-element/about.json
+++ b/src/components/page-element/about.json
@@ -1,0 +1,37 @@
+{
+  "collectionName": "components_page_element_abouts",
+  "info": {
+    "displayName": "about",
+    "icon": "phone",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "siteNavigation": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.site-navigation"
+    },
+    "callToAction": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.call-to-action"
+    },
+    "textField": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page-element.text-field"
+    },
+    "list": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page-element.list"
+    }
+  }
+}

--- a/src/components/page-element/experiment.json
+++ b/src/components/page-element/experiment.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_page_element_experiments",
+  "info": {
+    "displayName": "Experiment",
+    "icon": "chalkboard-teacher",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": [
+        "upcoming_projects",
+        "current_projects",
+        "past_projects"
+      ]
+    },
+    "link": {
+      "type": "string"
+    },
+    "description": {
+      "type": "richtext"
+    }
+  }
+}

--- a/src/components/page-element/home.json
+++ b/src/components/page-element/home.json
@@ -32,6 +32,11 @@
       "type": "component",
       "repeatable": true,
       "component": "page-element.text-field"
+    },
+    "list": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page-element.list"
     }
   }
 }

--- a/src/components/page-element/list.json
+++ b/src/components/page-element/list.json
@@ -1,0 +1,13 @@
+{
+  "collectionName": "components_page_element_lists",
+  "info": {
+    "displayName": "list",
+    "icon": "list"
+  },
+  "options": {},
+  "attributes": {
+    "listItem": {
+      "type": "string"
+    }
+  }
+}

--- a/src/components/page-element/project.json
+++ b/src/components/page-element/project.json
@@ -30,6 +30,11 @@
       "type": "component",
       "repeatable": false,
       "component": "page-element.call-to-action"
+    },
+    "siteNavigation": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.site-navigation"
     }
   }
 }

--- a/src/components/page-element/project.json
+++ b/src/components/page-element/project.json
@@ -1,0 +1,35 @@
+{
+  "collectionName": "components_page_element_projects",
+  "info": {
+    "displayName": "projects",
+    "icon": "book",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "path": {
+      "type": "string"
+    },
+    "experiment": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.experiment"
+    },
+    "filterText": {
+      "type": "string"
+    },
+    "textField": {
+      "type": "component",
+      "repeatable": true,
+      "component": "page-element.text-field"
+    },
+    "callToAction": {
+      "type": "component",
+      "repeatable": false,
+      "component": "page-element.call-to-action"
+    }
+  }
+}

--- a/src/components/page-element/site-navigation.json
+++ b/src/components/page-element/site-navigation.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_page_element_site_navigations",
+  "info": {
+    "displayName": "siteNavigation",
+    "icon": "link"
+  },
+  "options": {},
+  "attributes": {
+    "siteTitle": {
+      "type": "string"
+    },
+    "home": {
+      "type": "string"
+    },
+    "projects": {
+      "type": "string"
+    },
+    "about": {
+      "type": "string"
+    },
+    "signupInfo": {
+      "type": "string"
+    },
+    "signup": {
+      "type": "string"
+    }
+  }
+}

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-02-28T16:57:32.472Z"
+    "x-generation-date": "2022-03-03T15:38:32.407Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-03-03T15:38:32.407Z"
+    "x-generation-date": "2022-03-04T16:37:29.621Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -3988,6 +3988,85 @@
                                   }
                                 }
                               },
+                              "projects": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  },
+                                  "experiment": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "status": {
+                                        "type": "string",
+                                        "enum": [
+                                          "upcoming_projects",
+                                          "current_projects",
+                                          "past_projects"
+                                        ]
+                                      },
+                                      "link": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "filterText": {
+                                    "type": "string"
+                                  },
+                                  "textField": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "heading": {
+                                          "type": "string"
+                                        },
+                                        "paragraph": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "callToAction": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "href": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
                               "createdAt": {
                                 "type": "string",
                                 "format": "date-time"
@@ -5019,6 +5098,85 @@
                                 }
                               }
                             },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -5565,6 +5723,73 @@
                           }
                         }
                       },
+                      "projects": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "experiment": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "upcoming_projects",
+                                  "current_projects",
+                                  "past_projects"
+                                ]
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "filterText": {
+                            "type": "string"
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -6072,6 +6297,85 @@
                                       "paragraph": {
                                         "type": "string"
                                       }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
                                     }
                                   }
                                 }
@@ -7017,6 +7321,85 @@
                                 }
                               }
                             },
+                            "projects": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "path": {
+                                  "type": "string"
+                                },
+                                "experiment": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "status": {
+                                      "type": "string",
+                                      "enum": [
+                                        "upcoming_projects",
+                                        "current_projects",
+                                        "past_projects"
+                                      ]
+                                    },
+                                    "link": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "filterText": {
+                                  "type": "string"
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -7569,6 +7952,73 @@
                                 "paragraph": {
                                   "type": "string"
                                 }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "projects": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "string"
+                          },
+                          "experiment": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string",
+                                "enum": [
+                                  "upcoming_projects",
+                                  "current_projects",
+                                  "past_projects"
+                                ]
+                              },
+                              "link": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "filterText": {
+                            "type": "string"
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
                               }
                             }
                           }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-03-04T16:37:29.621Z"
+    "x-generation-date": "2022-03-04T16:59:47.187Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -4064,6 +4064,32 @@
                                         "type": "string"
                                       }
                                     }
+                                  },
+                                  "siteNavigation": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "siteTitle": {
+                                        "type": "string"
+                                      },
+                                      "home": {
+                                        "type": "string"
+                                      },
+                                      "projects": {
+                                        "type": "string"
+                                      },
+                                      "about": {
+                                        "type": "string"
+                                      },
+                                      "signupInfo": {
+                                        "type": "string"
+                                      },
+                                      "signup": {
+                                        "type": "string"
+                                      }
+                                    }
                                   }
                                 }
                               },
@@ -5174,6 +5200,32 @@
                                       "type": "string"
                                     }
                                   }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -5787,6 +5839,29 @@
                                 "type": "string"
                               }
                             }
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
                           }
                         }
                       },
@@ -6375,6 +6450,32 @@
                                       "type": "string"
                                     },
                                     "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
                                       "type": "string"
                                     }
                                   }
@@ -7397,6 +7498,32 @@
                                       "type": "string"
                                     }
                                   }
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -8018,6 +8145,29 @@
                                 "type": "string"
                               },
                               "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
                                 "type": "string"
                               }
                             }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-03-04T16:59:47.187Z"
+    "x-generation-date": "2022-03-04T17:01:23.760Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -4093,6 +4093,97 @@
                                   }
                                 }
                               },
+                              "about": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string"
+                                  },
+                                  "title": {
+                                    "type": "string"
+                                  },
+                                  "description": {
+                                    "type": "string"
+                                  },
+                                  "siteNavigation": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "siteTitle": {
+                                        "type": "string"
+                                      },
+                                      "home": {
+                                        "type": "string"
+                                      },
+                                      "projects": {
+                                        "type": "string"
+                                      },
+                                      "about": {
+                                        "type": "string"
+                                      },
+                                      "signupInfo": {
+                                        "type": "string"
+                                      },
+                                      "signup": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "callToAction": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "title": {
+                                        "type": "string"
+                                      },
+                                      "href": {
+                                        "type": "string"
+                                      },
+                                      "text": {
+                                        "type": "string"
+                                      },
+                                      "description": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "textField": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "heading": {
+                                          "type": "string"
+                                        },
+                                        "paragraph": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "listItem": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
                               "createdAt": {
                                 "type": "string",
                                 "format": "date-time"
@@ -5229,6 +5320,97 @@
                                 }
                               }
                             },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -5865,6 +6047,82 @@
                           }
                         }
                       },
+                      "about": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
                       "createdAt": {
                         "type": "string",
                         "format": "date-time"
@@ -6477,6 +6735,97 @@
                                     },
                                     "signup": {
                                       "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
                                     }
                                   }
                                 }
@@ -7527,6 +7876,97 @@
                                 }
                               }
                             },
+                            "about": {
+                              "type": "object",
+                              "properties": {
+                                "id": {
+                                  "type": "string"
+                                },
+                                "title": {
+                                  "type": "string"
+                                },
+                                "description": {
+                                  "type": "string"
+                                },
+                                "siteNavigation": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "siteTitle": {
+                                      "type": "string"
+                                    },
+                                    "home": {
+                                      "type": "string"
+                                    },
+                                    "projects": {
+                                      "type": "string"
+                                    },
+                                    "about": {
+                                      "type": "string"
+                                    },
+                                    "signupInfo": {
+                                      "type": "string"
+                                    },
+                                    "signup": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "callToAction": {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string"
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "href": {
+                                      "type": "string"
+                                    },
+                                    "text": {
+                                      "type": "string"
+                                    },
+                                    "description": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "textField": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "heading": {
+                                        "type": "string"
+                                      },
+                                      "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
                             "createdAt": {
                               "type": "string",
                               "format": "date-time"
@@ -8169,6 +8609,82 @@
                               },
                               "signup": {
                                 "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "about": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "siteNavigation": {
+                            "type": "object",
+                            "properties": {
+                              "siteTitle": {
+                                "type": "string"
+                              },
+                              "home": {
+                                "type": "string"
+                              },
+                              "projects": {
+                                "type": "string"
+                              },
+                              "about": {
+                                "type": "string"
+                              },
+                              "signupInfo": {
+                                "type": "string"
+                              },
+                              "signup": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "callToAction": {
+                            "type": "object",
+                            "properties": {
+                              "title": {
+                                "type": "string"
+                              },
+                              "href": {
+                                "type": "string"
+                              },
+                              "text": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "textField": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "heading": {
+                                  "type": "string"
+                                },
+                                "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
                               }
                             }
                           }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-03-04T17:01:23.760Z"
+    "x-generation-date": "2022-03-04T18:17:10.718Z"
   },
   "x-strapi-config": {
     "path": "/documentation",
@@ -3985,6 +3985,20 @@
                                         }
                                       }
                                     }
+                                  },
+                                  "list": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "listItem": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
                                   }
                                 }
                               },
@@ -5212,6 +5226,20 @@
                                       }
                                     }
                                   }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -5954,6 +5982,17 @@
                                 }
                               }
                             }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
+                                  "type": "string"
+                                }
+                              }
+                            }
                           }
                         }
                       },
@@ -6628,6 +6667,20 @@
                                         "type": "string"
                                       },
                                       "paragraph": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
                                         "type": "string"
                                       }
                                     }
@@ -7768,6 +7821,20 @@
                                       }
                                     }
                                   }
+                                },
+                                "list": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "id": {
+                                        "type": "string"
+                                      },
+                                      "listItem": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
                                 }
                               }
                             },
@@ -8517,6 +8584,17 @@
                                   "type": "string"
                                 },
                                 "paragraph": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "list": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "listItem": {
                                   "type": "string"
                                 }
                               }


### PR DESCRIPTION
# Description

Added content types for projects page and about page. 

## Test Instructions

Start the development server `yarn develop`, go to content manager in admin panel, checkout the content types for project and about page.
