### PR TITLE
Strapi note plugin

### DIFF
--- a/.strapi-updater.json
+++ b/.strapi-updater.json
@@ -1,5 +1,5 @@
 {
 	"latest": "4.1.7",
-	"lastUpdateCheck": 1649357118014,
+	"lastUpdateCheck": 1649691329682,
 	"lastNotification": 1649357117995
 }

--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,18 +1,21 @@
-module.exports= ({env}) => {
-  var storage = env("STRAPI_STORAGE", "local")
-  if( storage === "azure"){
+module.exports = ({ env }) => {
+  var storage = env("STRAPI_STORAGE", "local");
+  if (storage === "azure") {
     return {
+      "entity-notes": {
+        enabled: true,
+      },
       upload: {
-        provider: 'azure-storage',
+        provider: "azure-storage",
         providerOptions: {
-          account: env('STORAGE_ACCOUNT'),
-          accountKey: env('STORAGE_ACCOUNT_KEY'),
-          serviceBaseURL: env('STORAGE_URL'),
-          containerName: env('STORAGE_CONTAINER_NAME'),
-          defaultPath: 'assets',
-          maxConcurrent: 10
-        }
-      }
-    }
+          account: env("STORAGE_ACCOUNT"),
+          accountKey: env("STORAGE_ACCOUNT_KEY"),
+          serviceBaseURL: env("STORAGE_URL"),
+          containerName: env("STORAGE_CONTAINER_NAME"),
+          defaultPath: "assets",
+          maxConcurrent: 10,
+        },
+      },
+    };
   }
 };

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "maintenance": "zx ./maintenance/runner.mjs"
   },
   "devDependencies": {
+    "csv": "^6.0.5",
     "jest": "^27.4.7",
+    "mkdirp": "^1.0.4",
+    "rimraf": "^3.0.2",
     "sqlite3": "^5.0.2",
     "supertest": "^6.2.2",
     "yarn-audit-fix": "^3.3.1",
-    "csv": "^6.0.5",
-    "mkdirp": "^1.0.4",
-    "rimraf": "^3.0.2",
     "zx": "^4.3.0"
   },
   "dependencies": {
@@ -36,6 +36,7 @@
     "node-fetch": "2",
     "pg": "latest",
     "react-router-dom": "^6.2.1",
+    "strapi-plugin-notes": "^1.0.0",
     "strapi-provider-upload-azure-storage": "2.0.0",
     "styled-components": "^5.3.3"
   },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2022-04-01T14:34:04.288Z"
+    "x-generation-date": "2022-04-11T15:37:48.671Z"
   },
   "x-strapi-config": {
     "path": "/documentation",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13194,6 +13194,11 @@ std-env@^2.2.1:
   dependencies:
     ci-info "^3.1.1"
 
+strapi-plugin-notes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strapi-plugin-notes/-/strapi-plugin-notes-1.0.0.tgz#3a84241855cf81c176171e5573fbe3e029a9597e"
+  integrity sha512-BMMLPVm30Hvxxov+SWzmmNw4kHf9w1AhbomBNkthtDCl3HSOyUw+P8WTeuZ6e1XcKR49pTO/CEerw8zGBdOuGg==
+
 strapi-provider-upload-azure-storage@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strapi-provider-upload-azure-storage/-/strapi-provider-upload-azure-storage-2.0.0.tgz#487c750b8cdc3a0b5d3e450ec1277a0e4ff8b7d9"


### PR DESCRIPTION
# Description

In this pr, I added a Strapi plugin to create notes on admin panel. [This plugin](https://market.strapi.io/plugins/strapi-plugin-notes) allow devs to add instruction/description text to entity records to help content editor have better understanding on how each content field works. 

I also want to test if plugin works in production.  

## Test Instructions

1. `yarn` or `yarn install`
2. Start the development server `yarn develop`
3. Go to `Content manager`, under Collection types, select `PageContent` and choose any record.
4. There is an `add a note` button located on the panel on the right, under internationalization. When you click on the button, a modal will popup, you can enter title and comment, when you finish, click save.
5. You can add as many notes as you want, you can also delete any notes you don't want anymore.
